### PR TITLE
Fix CoM crash when deleting cipher.

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -697,6 +697,8 @@
     <string name="slDirectHit">Coup au but! (-%1$d Écrans)</string>
     <string name="slEnemyHitPlayer">Votre adversaire vous a touché (-%1$d Écrans).</string>
     <string name="shipAndWeapons"><![CDATA[Vaisseau & Armes]]></string>
+    <string name="cypher">Code</string>
+    <string name="deleteCypher">Supprimer ce code ?</string>
 
     <!--SpellBreaker-->
     <string name="gold2">Or</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -642,7 +642,9 @@
     <string name="savegameImportNotExecuted">A importação de jogos gravados necessita de permissões de leitura sobre o armazenamento externo para funcionar</string>
     <string name="savegameImportInfo">O formato de jogos gravados nesta aplicação mudou na version 0.38-beta. Esta aplicação tenta importar os ficheiros existentes para o novo formato. Se porventura os jogos não estiverem disponívels no ecrã de carregamento por favor utilize a opção \"Importar Jogos Gravados\" no ecrã de \"Preferências\" para o fazer manualmente.</string>
     <string name="oneStrikeCombat">Combate Único</string>
+    <string name="cypher">Cifra</string>
     <string name="addCypher">Adicionar cifra</string>
+    <string name="deleteCypher">Apagar cifra?</string>
 
     <!--Sky Lord-->
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1142,7 +1142,9 @@
     <string name="currentVersion" translatable="false">currentVersion</string>
     <string name="savegameImportInfo">The savegame format of this app has changed in version 0.38-beta. This app attempts to auto import the exiting files to the new format. If by any chance you should have saved games in the Load Game list and they are not available, please use the option \"Import Savegames\" in the \"Settings\" screen to do it manually.</string>
     <string name="info">Information</string>
+    <string name="cypher">Cypher</string>
     <string name="addCypher">Add Cypher</string>
+    <string name="deleteCypher">Delete cypher?</string>
 
     <!--Sky Lord-->
     <string name="lasers">Lasers:</string>

--- a/src/main/java/pt/joaomneto/titancompanion/adventure/impl/COMAdventure.kt
+++ b/src/main/java/pt/joaomneto/titancompanion/adventure/impl/COMAdventure.kt
@@ -51,7 +51,7 @@ class COMAdventure : TWOFMAdventure(
     var kuddamKilled: List<Kuddam> = emptyList()
     override var gold: Int = 0
     var fuel: Int = 0
-    var cyphers: List<String> = emptyList()
+    var cyphers: MutableList<String> = mutableListOf()
     var tabashaSpecialSkill = false
 
     override fun loadAdventureSpecificValuesFromFile() {

--- a/src/main/java/pt/joaomneto/titancompanion/adventure/impl/fragments/com/COMAdventureNotesFragment.kt
+++ b/src/main/java/pt/joaomneto/titancompanion/adventure/impl/fragments/com/COMAdventureNotesFragment.kt
@@ -37,7 +37,7 @@ class COMAdventureNotesFragment : AdventureNotesFragment() {
             OnClickListener {
                 val alert = AlertDialog.Builder(adv)
 
-                alert.setTitle(R.string.note)
+                alert.setTitle(R.string.cypher)
 
                 // Set an EditText view to get user input
                 val input = EditText(adv)
@@ -51,7 +51,7 @@ class COMAdventureNotesFragment : AdventureNotesFragment() {
                     { _, _ ->
                         val value = input.text.toString()
                         if (value.isNotBlank()) {
-                            adv.cyphers = adv.cyphers.plus(value.trim { it <= ' ' })
+                            adv.cyphers.add(value.trim { it <= ' ' })
                             (cypherList!!.adapter as ArrayAdapter<String>).notifyDataSetChanged()
                         }
                     }
@@ -73,16 +73,18 @@ class COMAdventureNotesFragment : AdventureNotesFragment() {
         )
         cypherList.adapter = adapter
 
-        cypherList.onItemLongClickListener = OnItemLongClickListener { _, _, arg2, _ ->
+        cypherList.onItemLongClickListener = OnItemLongClickListener { _, _, position, _ ->
             val builder = AlertDialog.Builder(adv)
-            builder.setTitle(R.string.deleteKeyword)
+            builder.setTitle(R.string.deleteCypher)
                 .setCancelable(false)
                 .setNegativeButton(
                     R.string.close
                 ) { dialog, _ -> dialog.cancel() }
             builder.setPositiveButton(R.string.ok) { _, _ ->
-                adv.cyphers = adv.cyphers.minus(adv.cyphers[arg2])
-                (cypherList!!.adapter as ArrayAdapter<String>).notifyDataSetChanged()
+                if (adv.cyphers.size > position) {
+                    adv.cyphers.removeAt(position)
+                    (cypherList!!.adapter as ArrayAdapter<String>).notifyDataSetChanged()
+                }
             }
 
             val alert = builder.create()


### PR DESCRIPTION
When deleting a cipher in Chasms of Malice (CoM), the cipher doesn't disappear – trying to
delete it again causes the application to crash.  This fix makes the list behind ciphers mutable, and adds/removes as needed.  It also fixes the various labels to indicate “Cypher” rather than notes.

This issue probably also shows in other titles, I haven't checked yet, but the various Note-like custom fields should probably be made generic to handle this in a nicer way.